### PR TITLE
🔒 Fix Reflected XSS in invite link parameter

### DIFF
--- a/invite/index.html
+++ b/invite/index.html
@@ -346,7 +346,10 @@
         function updateDynamicText(lang) {
             if (creatorName) {
                 const prefix = lang === 'de' ? 'Du wurdest eingeladen von' : 'You were invited by';
-                greetingText.innerHTML = `${prefix} <span class="text-accent font-black italic text-lg ml-1">${creatorName}</span>!`;
+
+                // Safe DOM manipulation to prevent Reflected XSS
+                greetingText.innerHTML = `${prefix} <span id="creator-name-span" class="text-accent font-black italic text-lg ml-1"></span>!`;
+                document.getElementById('creator-name-span').textContent = creatorName;
                 
                 // Show dynamic avatar ONLY if the secondary MC name box was used
                 if (mcHeadName) {


### PR DESCRIPTION
🎯 **What:** The `creatorName` parameter derived from the URL was interpolated directly into `greetingText.innerHTML` without sanitization, leading to a Reflected Cross-Site Scripting (XSS) vulnerability.

⚠️ **Risk:** An attacker could craft a malicious invite link containing JavaScript code. If a victim clicked this link, the script would execute in their browser session, potentially stealing cookies, tracking data, or manipulating the UI on behalf of the user.

🛡️ **Solution:** The dynamic string assignment was split. The HTML structure is now safely assigned using `innerHTML` with an empty `<span>` element. The untrusted `creatorName` is then safely injected into that `<span>` using `textContent`, which natively encodes any HTML/JavaScript tags and prevents execution.

---
*PR created automatically by Jules for task [15655974850169281928](https://jules.google.com/task/15655974850169281928) started by @der46er*