### PR TITLE
Fix modpack side menu link

### DIFF
--- a/news/index.html
+++ b/news/index.html
@@ -121,7 +121,7 @@
             <a href="https://craftify-mc.eu/" class="hover:translate-x-2 transition-transform" data-i18n="navHome">Home</a>
             <a href="https://craftify-mc.eu/news" class="text-green-400" data-i18n="navNews">News</a>
             <a href="https://craftify-mc.eu/ip" class="hover:translate-x-2 transition-transform" data-i18n="navIp">IP-Address</a>
-            <a href="https://craftify-mc.eu/mods" class="hover:translate-x-2 transition-transform" data-i18n="navMods">Modpack</a>
+            <a href="https://craftify-mc.eu/modpack" class="hover:translate-x-2 transition-transform" data-i18n="navMods">Modpack</a>
             <a href="https://craftify-mc.eu/map" class="hover:translate-x-2 transition-transform" data-i18n="navMap">Map</a>
             <a href="https://craftify-mc.eu/status" class="hover:translate-x-2 transition-transform" data-i18n="navStatus">Status</a>
             <a href="https://craftify-mc.eu/videos" class="hover:translate-x-2 transition-transform" data-i18n="navVideos">Videos</a>

--- a/server.log
+++ b/server.log
@@ -1,2 +1,12 @@
-127.0.0.1 - - [22/May/2026 22:22:55] "GET /chat/ HTTP/1.1" 200 -
-127.0.0.1 - - [22/May/2026 22:22:56] "GET /chat/utils.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:45:19] "GET /news/ HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:45:19] "GET /news/parseNewsDate.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:45:19] "GET /assets/js/analytics.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:10] "GET /news/ HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:10] "GET /assets/js/analytics.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:10] "GET /news/parseNewsDate.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:27] "GET /news/ HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:27] "GET /news/parseNewsDate.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:46:27] "GET /assets/js/analytics.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:47:27] "GET /news/ HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:47:27] "GET /news/parseNewsDate.js HTTP/1.1" 200 -
+127.0.0.1 - - [22/May/2026 22:47:27] "GET /assets/js/analytics.js HTTP/1.1" 200 -


### PR DESCRIPTION
Replaces incorrect `/mods` link with `/modpack` in `news/index.html` to align with the rest of the site and resolve navigation issues.

---
*PR created automatically by Jules for task [2717207375657061221](https://jules.google.com/task/2717207375657061221) started by @der46er*